### PR TITLE
feat: :sparkles: eden treaty path params function

### DIFF
--- a/.changeset/sour-flowers-divide.md
+++ b/.changeset/sour-flowers-divide.md
@@ -1,0 +1,8 @@
+---
+'@ap0nia/eden-svelte-query': major
+'@ap0nia/eden-react-query': major
+'@ap0nia/eden': major
+'@ap0nia/eden-next-query': major
+---
+
+feat: fully compliant treaty implementation

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,25 +23,26 @@ jobs:
       RAW_COMMIT_MESSAGE: 'chore: release package(s)'
 
     steps:
-      - name: Checkout repository
+      - name: ⏬ Checkout repository
         uses: actions/checkout@v3
 
-      - name: Setup Node.js and pnpm
+      - name: 🕺 Setup Node.js and pnpm
         uses: ./.github/actions/setup-node-and-pnpm
 
-      - name: Install dependencies
+      - name: 📦 Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Build
+      - name: 🔨 Build
         run: pnpm --filter \!@elysiajs/documentation build
 
-      - name: Generate commit message
+      - name: ✏️ Generate commit message
         id: devmoji
         run: |
           MESSAGE=$(npx --no -- devmoji --format shortcode --text ${{ toJSON(env.RAW_COMMIT_MESSAGE) }})
           echo "MESSAGE=$MESSAGE" >> $GITHUB_OUTPUT
 
-      - name: Create release pull request or publish to npm
+      - name: 🚀 Create pull request or publish to npm
+        id: changesets
         uses: changesets/action@v1
         with:
           publish: pnpm publish -r
@@ -50,3 +51,18 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: 👀 Get package.json version
+        id: package-json-version
+        if: steps.changesets.outputs.published
+        uses: martinbeentjes/npm-get-version-action@v1.3.1
+
+      - name: 🎁 Create Release
+        id: create-release
+        if: steps.changesets.outputs.published
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.package-json-version.outputs.current-version }}
+          release_name: ${{ github.event.pull_request.title }}

--- a/README.md
+++ b/README.md
@@ -12,6 +12,22 @@
 
 </div>
 
+## Overview
+
+`eden-query` allows you to connect to your `elysia` backend with end-to-end type-safety and powerful
+asynchronous state management from your frontend.
+
+### Features
+
+- 🌎 Framework agnostic.
+- 🦺 Full end-to-end type-safety.
+- ✅ Fully supports REST API standards.
+- 🖥️SSR support and examples.
+- ✨ Reactive and infinite queries.
+- ⚡ Batching requests on both the client and server.
+- 🔗 Links for customizing the flow of data.
+- 👀 Data transformers for enhanced JSON handling.
+
 ## Get Started
 
 ### Installation
@@ -85,24 +101,22 @@ export type App = typeof app
 
 </details>
 
-## Overview
-
 ## Core Technologies
 
 `eden-query` is a combination of three technologies:
 
-**_Elysia.js_**
+_*Elysia.js*_
 
 TypeScript server framework supercharged by Bun with End-to-End Type Safety,
 unified type system, and outstanding developer experience.
 Learn more about it from [the official documentation](https://elysiajs.com)!
 
-**_Eden_**
+_*Eden*_
 
 A type-safeREST client that offers end-to-end typesafety.
 Learn more about it from [the official documentation](https://elysiajs.com/eden/overview.html)!
 
-**_Tanstack-Query_**
+_*Tanstack-Query*_
 
 A full featured asynchronous state management solution.
 Learn more about it from [the offical documentation](https://tanstack.com/query/latest)

--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
-# eden-query
+<h1 align="center">eden-query</h1>
+
 > elysia.js-eden + tanstack-query integrations
+
+<div>
+![NPM Downloads](https://img.shields.io/npm/dw/%40ap0nia%2Feden-svelte-query)
+</div>

--- a/README.md
+++ b/README.md
@@ -3,7 +3,87 @@
 > elysia.js-eden + tanstack-query integrations
 
 <div align="center">
+
   <img alt="NPM Downloads" src="https://img.shields.io/npm/dw/%40ap0nia%2Feden-svelte-query">
   <img alt="NPM License" src="https://img.shields.io/npm/l/%40ap0nia%2Feden-svelte-query">
   <img alt="GitHub Actions Workflow Status" src="https://img.shields.io/github/actions/workflow/status/ap0nia/eden-query/release.yml">
+
+  ![NPM Downloads](https://img.shields.io/npm/dm/%40ap0nia%2Feden-svelte-query)
+
 </div>
+
+## Get Started
+
+### Installation
+
+```sh
+# npm
+npm install @ap0nia/eden-react-query
+
+# yarn
+yarn add @ap0nia/eden-react-query
+
+# pnpm
+pnpm add @ap0nia/eden-react-query
+```
+
+### Usage
+
+```tsx
+import { eden } from '~/lib/eden'
+
+export function Products() {
+  const { data } = eden.api.products.get.useQuery()
+
+  return (
+    <ul>
+      {data?.map(product => (
+        <li>{product.name}</li>
+      )}
+    </ul>
+  )
+}
+```
+
+<details>
+  <summary>Click me</summary>
+
+  ```tsx
+  import { eden } from '~/lib/eden'
+
+  export function Products() {
+    const { data } = eden.api.products.get.useQuery()
+
+    return (
+      <ul>
+        {data?.map(product => (
+          <li>{product.name}</li>
+        )}
+      </ul>
+    )
+  }
+  ```
+
+</details>
+
+## Overview
+
+## Core Technologies
+
+`eden-query` is a combination of three technologies:
+
+**_Elysia.js_**
+
+TypeScript server framework supercharged by Bun with End-to-End Type Safety,
+unified type system, and outstanding developer experience.
+Learn more about it from [the official documentation](https://elysiajs.com)!
+
+**_Eden_**
+
+A type-safeREST client that offers end-to-end typesafety.
+Learn more about it from [the official documentation](https://elysiajs.com/eden/overview.html)!
+
+**_Tanstack-Query_**
+
+A full featured asynchronous state management solution.
+Learn more about it from [the offical documentation](https://tanstack.com/query/latest)

--- a/README.md
+++ b/README.md
@@ -101,6 +101,10 @@ export type App = typeof app
 
 </details>
 
+## Learn More
+
+To see more advanced examples and usage of the integration, read [the full documentation](ap0nia.github.io/eden-query).
+
 ## Core Technologies
 
 `eden-query` is a combination of three technologies:

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 > elysia.js-eden + tanstack-query integrations
 
-<div>
+<div align="center">
   <img alt="NPM Downloads" src="https://img.shields.io/npm/dw/%40ap0nia%2Feden-svelte-query">
+  <img alt="NPM License" src="https://img.shields.io/npm/l/%40ap0nia%2Feden-svelte-query">
+  <img alt="GitHub Actions Workflow Status" src="https://img.shields.io/github/actions/workflow/status/ap0nia/eden-query/release.yml">
 </div>

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@
 
 <div align="center">
 
-  <img alt="NPM Downloads" src="https://img.shields.io/npm/dw/%40ap0nia%2Feden-svelte-query">
-  <img alt="NPM License" src="https://img.shields.io/npm/l/%40ap0nia%2Feden-svelte-query">
-  <img alt="GitHub Actions Workflow Status" src="https://img.shields.io/github/actions/workflow/status/ap0nia/eden-query/release.yml">
-
-  ![NPM Downloads](https://img.shields.io/npm/dm/%40ap0nia%2Feden-svelte-query)
+![NPM License](https://img.shields.io/npm/l/%40ap0nia%2Feden-svelte-query)
+![Publish](https://img.shields.io/github/actions/workflow/status/ap0nia/eden-query/release.yml)
+![GitHub Release](https://img.shields.io/github/v/release/ap0nia/eden-query)
+![GitHub Repo stars](https://img.shields.io/github/stars/ap0nia/eden-query)
+![NPM Downloads](https://img.shields.io/npm/dm/%40ap0nia%2Feden)
 
 </div>
 
@@ -18,27 +18,27 @@
 
 ```sh
 # npm
-npm install @ap0nia/eden-react-query
+npm install elysia @ap0nia/eden-react-query
 
 # yarn
-yarn add @ap0nia/eden-react-query
+yarn add elysia @ap0nia/eden-react-query
 
 # pnpm
-pnpm add @ap0nia/eden-react-query
+pnpm add elysia @ap0nia/eden-react-query
 ```
 
 ### Usage
 
 ```tsx
-import { eden } from '~/lib/eden'
+import { eden } from './eden'
 
 export function Products() {
   const { data } = eden.api.products.get.useQuery()
 
   return (
     <ul>
-      {data?.map(product => (
-        <li>{product.name}</li>
+      {data?.map((product) => (
+        <li id={product.id}>{product.name}</li>
       )}
     </ul>
   )
@@ -46,23 +46,42 @@ export function Products() {
 ```
 
 <details>
-  <summary>Click me</summary>
+  <summary>eden.ts</summary>
 
-  ```tsx
-  import { eden } from '~/lib/eden'
+```tsx
+import type { App } from './server'
+import { createEdenTreatyReactQuery } from '@ap0nia/eden-react-query'
 
-  export function Products() {
-    const { data } = eden.api.products.get.useQuery()
+export const eden = createEdenTreatyReactQuery<App>()
+```
 
-    return (
-      <ul>
-        {data?.map(product => (
-          <li>{product.name}</li>
-        )}
-      </ul>
-    )
-  }
-  ```
+</details>
+
+<details>
+  <summary>server.ts</summary>
+
+```tsx
+import { Elysia } from 'elysia'
+
+const app = new Elysia().get('/api/products', () => {
+  return [
+    {
+      id: 0,
+      name: 'Product 0',
+    },
+    {
+      id: 1,
+      name: 'Product 1',
+    },
+    {
+      id: 2,
+      name: 'Product 2',
+    },
+  ]
+})
+
+export type App = typeof app
+```
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -3,5 +3,5 @@
 > elysia.js-eden + tanstack-query integrations
 
 <div>
-![NPM Downloads](https://img.shields.io/npm/dw/%40ap0nia%2Feden-svelte-query)
+  <img alt="NPM Downloads" src="https://img.shields.io/npm/dw/%40ap0nia%2Feden-svelte-query">
 </div>

--- a/documentation/docs/eden-query/react/aborting.md
+++ b/documentation/docs/eden-query/react/aborting.md
@@ -119,10 +119,8 @@ import { eden } from './eden'
 function PostViewPage() {
   const { query } = useRouter()
 
-  const postQuery = eden.post[':id'].get.useQuery(
-    {
-      query: { id: query.id },
-    },
+  const postQuery = eden.post({ id: query.id }).get.useQuery(
+    undefined,
     { eden: { abortOnUnmount: true } },
   )
 

--- a/documentation/docs/eden-query/react/disabling.md
+++ b/documentation/docs/eden-query/react/disabling.md
@@ -24,11 +24,19 @@ head:
 import { Elysia, t } from 'elysia'
 import { batchPlugin } from '@ap0nia/eden-react-query'
 
-export const app = new Elysia().use(batchPlugin()).get('/user/:name', (context) => {
-  return {
-    name: context.params.name,
-  }
-})
+export const app = new Elysia().use(batchPlugin()).get(
+  '/user',
+  (context) => {
+    return {
+      name: context.query.name,
+    }
+  },
+  {
+    query: t.Object({
+      name: t.String(),
+    }),
+  },
+)
 
 export type App = typeof app
 ```
@@ -80,10 +88,10 @@ import { eden } from './eden'
 export function MyComponent() {
   const [name, setName] = useState<string | undefined>()
 
-  const result = eden.user[':name'].get.useQuery(name ? { params: { name } } : skipToken)
+  const result = eden.user.get.useQuery(name ? { name } : skipToken)
 
   result
-  // ^?
+  //  ^?
 }
 ```
 

--- a/documentation/docs/eden-query/react/index.md
+++ b/documentation/docs/eden-query/react/index.md
@@ -97,7 +97,7 @@ import React from 'react'
 import { eden } from './eden'
 
 export default function IndexPage() {
-  const helloQuery = eden.hello.get.useQuery({ query: { name: 'Bob' } })
+  const helloQuery = eden.hello.get.useQuery({ name: 'Bob' })
   const goodbyeMutation = eden.goodbye.post.useMutation()
 
   return (

--- a/documentation/docs/eden-query/react/inferring-types.md
+++ b/documentation/docs/eden-query/react/inferring-types.md
@@ -14,4 +14,93 @@ head:
       content: Inferring Types Eden-React-Query - ElysiaJS
 ---
 
-# Inferring Types (WIP...)
+# Inferring Types
+
+1. Create Elysia application
+
+::: code-group
+
+```typescript twoslash include eq-react-infer-application [src/server.ts]
+import { Elysia, t } from 'elysia'
+import { batchPlugin } from '@ap0nia/eden-svelte-query'
+
+export const app = new Elysia().use(batchPlugin()).get('/post/:id', (context) => {
+  return {
+    id: context.params.id,
+    title: 'Look me up!',
+  }
+})
+
+export type App = typeof app
+```
+
+:::
+
+2. Initialize Eden-Query Hooks and Types
+
+::: tip
+`InferRouteOptions`: gets the `query` and `params` required for the route.
+
+`InferRouteBody`: gets the `body` required for the route, e.g. POST, PATCH, etc. endpoints.
+:::
+
+::: code-group
+
+```typescript twoslash [src/lib/eden.ts]
+// @noErrors
+
+// @filename: src/server.ts
+// ---cut---
+// @include: eq-react-infer-application
+
+// @filename: src/lib/eden.ts
+// ---cut---
+import {
+  createEdenTreatyReactQuery,
+  type InferTreatyQueryInput,
+  type InferTreatyQueryOutput,
+} from '@ap0nia/eden-react-query'
+import type { App } from '../server'
+
+export const eden = createEdenTreatyReactQuery<App>()
+
+export type InferInput = InferTreatyQueryInput<App>
+
+export type InferOutput = InferTreatyQueryOutput<App>
+
+type A = InferInput['post']['
+                          // ^|
+
+
+type B = InferInput['post'][':id']['
+                                 // ^|
+
+
+type C = InferInput['post'][':id']['get']
+
+type PrettifiedInput = { [K in keyof C]: C[K] }
+
+type InputQuery = PrettifiedInput['query']
+
+type InputParams = PrettifiedInput['params']
+```
+
+:::
+
+3. Use inference helpers
+
+::: code-group
+
+```svelte [src/routes/+page.svelte]
+<script lang="ts">
+  import { eden, type InferInput } from '$lib/eden'
+
+  const input = writable<InferInput['post'][':id']['get']>({ params: { id: '' }})
+
+  const post = eden.post[':id'].get.createQuery(input)
+</script>
+
+<input bind:value={$input.params.id}>
+```
+
+:::

--- a/documentation/docs/eden-query/react/setup.md
+++ b/documentation/docs/eden-query/react/setup.md
@@ -192,7 +192,7 @@ import React from 'react'
 import { eden } from './eden'
 
 export default function IndexPage() {
-  const userQuery = eden.user.get.useQuery({ query: { id: 'id_bilbo' }})
+  const userQuery = eden.user.get.useQuery({ id: 'id_bilbo' })
   const userCreator = eden.user.post.useMutation()
 
   return (

--- a/documentation/docs/eden-query/react/suspense.md
+++ b/documentation/docs/eden-query/react/suspense.md
@@ -120,7 +120,7 @@ import React from 'react'
 import { eden } from './eden'
 
 function PostView() {
-  const [post, postQuery] = eden.post[':id'].get.useSuspenseQuery({ params: { id: '1' }})
+  const [post, postQuery] = eden.post({ id: 1 }).get.useSuspenseQuery()
   //      ^?
 
   return <>{/* ... */}</>
@@ -153,7 +153,7 @@ import { eden } from './eden'
 function PostView() {
   const [{ pages }, allPostsQuery] = eden.post.all.get.useSuspenseInfiniteQuery(
     //      ^?
-    { query: {} },
+    undefined,
     {
       getNextPageParam(lastPage) {
         return lastPage.nextCursor
@@ -198,7 +198,7 @@ export type PostViewProps = {
 
 function PostView(props: PostViewProps) {
   const [posts, postQueries] = eden.useSuspenseQueries((e) => {
-    return props.postIds.map((id) => e.post[':id'].get({ params: { id } }))
+    return props.postIds.map((id) => e.post({ id }).get())
   })
   return /* */
 }

--- a/documentation/docs/eden-query/react/useInfiniteQuery.md
+++ b/documentation/docs/eden-query/react/useInfiniteQuery.md
@@ -136,9 +136,7 @@ import { eden } from './eden'
 
 export function MyComponent() {
   const myQuery = eden.infinitePosts.get.useInfiniteQuery(
-    {
-      query: { limit: 10 },
-    },
+    { limit: 10 },
     {
       getNextPageParam: (lastPage) => lastPage.nextCursor,
       // initialCursor: 1, // <-- optional you can pass an initialCursor

--- a/documentation/docs/eden-query/react/useQueries.md
+++ b/documentation/docs/eden-query/react/useQueries.md
@@ -121,7 +121,7 @@ export type MyProps = {
 
 export function MyComponent(props: MyProps) {
   const postQueries = eden.useQueries((e) => {
-    return props.postIds.map((id) => e.post[':id'].get({ params: { id } }))
+    return props.postIds.map((id) => e.post({ id }).get())
   })
 
   return /* [...] */
@@ -159,8 +159,8 @@ export type MyProps = {
 
 export function MyComponent(props: MyProps) {
   const [post, greeting] = eden.useQueries((e) => [
-    e.post[':id'].get({ params: { id: '1' } }, { enabled: false }),
-    e.greeting.get({ query: { text: 'world' }}),
+    e.post({ id: 1 }).get(undefined, { enabled: false }),
+    e.greeting.get({ text: 'world' }),
   ])
 
   const onButtonClick = () => {
@@ -199,8 +199,8 @@ export type MyProps = {
 export function MyComponent(props: MyProps) {
   const [post, greeting] = eden.useQueries(
     (e) => [
-      e.post[':id'].get({ params: { id: '1' } }),
-      e.greeting.get({ query: { text: 'world' } }),
+      e.post({ id: 1 }).get(),
+      e.greeting.get({ text: 'world' }),
     ],
     myCustomContext,
   )

--- a/documentation/docs/eden-query/react/useQuery.md
+++ b/documentation/docs/eden-query/react/useQuery.md
@@ -120,8 +120,8 @@ import { eden } from './eden'
 
 export function MyComponent() {
   // input is optional, so we don't have to pass the 'text' property in the query field.
-  const helloNoArgs = eden.hello.get.useQuery({ query: { }})
-  const helloWithArgs = eden.hello.get.useQuery({ query: { text: 'client' }})
+  const helloNoArgs = eden.hello.get.useQuery()
+  const helloWithArgs = eden.hello.get.useQuery({ text: 'client' })
 
   return (
     <div>

--- a/documentation/docs/eden-query/react/useUtils.md
+++ b/documentation/docs/eden-query/react/useUtils.md
@@ -230,7 +230,7 @@ function MyComponent() {
   const mutation = eden.post.edit.post.useMutation({
     onSuccess(input) {
       utils.post.all.invalidate()
-      utils.post[':id'].get.invalidate({ params: { id: input.post.id + ''} }) // Will not invalidate queries for other id's 👍
+      utils.post[':id'].get.invalidate({ params: { id: input.post.id + '' } }) // Will not invalidate queries for other id's 👍
     },
   })
 
@@ -281,15 +281,15 @@ export function MyComponent() {
 
   const invalidatePostById = () => {
     // 3️⃣
-    // All queries in the post router with input {id:1} invalidated 📭
-    utils.post[':id'].get.invalidate({ params: { id: '1' } })
+    // All queries in the post router with path params { id: 1 } invalidated 📭
+    utils.post({ id: 1 }).get.invalidate()
   }
 
   // Example queries
   eden.user.all.get.useQuery() // Would only be validated by 1️⃣ only.
   eden.post.all.get.useQuery() // Would be invalidated by 1️⃣ & 2️⃣
-  eden.post[':id'].get.useQuery({ params: { id: '1' } }) // Would be invalidated by 1️⃣, 2️⃣ and 3️⃣
-  eden.post[':id'].get.useQuery({ params: { id: '2' } }) // would be invalidated by 1️⃣ and 2️⃣ but NOT 3️⃣!
+  eden.post({ id: 1 }).get.useQuery() // Would be invalidated by 1️⃣, 2️⃣ and 3️⃣
+  eden.post({ id: 2 }).get.useQuery() // would be invalidated by 1️⃣ and 2️⃣ but NOT 3️⃣!
 }
 ```
 

--- a/documentation/docs/eden-query/svelte/aborting.md
+++ b/documentation/docs/eden-query/svelte/aborting.md
@@ -105,10 +105,8 @@ You may also override this behaviour at the query level.
 
   export let data: PageData
 
-  const postQuery = eden.post[':id'].get.useQuery(
-    {
-      query: { id: data.id },
-    },
+  const postQuery = eden.post({ id: data.id }).get.useQuery(
+    undefined,
     { eden: { abortOnUnmount: true } },
   )
 </script>

--- a/documentation/docs/eden-query/svelte/createQueries.md
+++ b/documentation/docs/eden-query/svelte/createQueries.md
@@ -110,7 +110,7 @@ export const eden = createEdenTreatySvelteQuery<App>()
   export let postIds: string[] = []
 
   const postQueries = eden.createQueries((e) => {
-    return props.postIds.map((id) => e.post[':id'].get({ id }))
+    return props.postIds.map((id) => e.post({ id }).get())
   })
 </script>
 
@@ -136,8 +136,8 @@ see the [tanstack useQuery](https://tanstack.com/query/v5/docs/framework/react/r
   export let postIds: string[] = []
 
   const [post, greeting] = eden.createQueries((e) => [
-    e.post[':id'].get({ params: { id: '1' } }, { enabled: false }),
-    e.greeting.get({ query: { text: 'world' }}),
+    e.post({ id: 1 }).get(undefined, { enabled: false }),
+    e.greeting.get({ text: 'world' }),
   ])
 
   const onButtonClick = () => {
@@ -166,8 +166,8 @@ You can also pass in an optional Svelte Query context to override the default.
 
   const [post, greeting] = eden.createQueries(
     (e) => [
-      e.post[':id'].get({ params: { id: '1' } }),
-      e.greeting.get({ query: { text: 'world' } }),
+      e.post({ id: 1 }).get(),
+      e.greeting.get({ text: 'world' }),
     ],
     myCustomContext,
   )

--- a/documentation/docs/eden-query/svelte/createQuery.md
+++ b/documentation/docs/eden-query/svelte/createQuery.md
@@ -110,8 +110,8 @@ export const eden = createEdenTreatySvelteQuery<App>()
 <script lang="ts">
   import { eden } from '$/lib/eden'
 
-  const helloNoArgs = eden.hello.get.useQuery({ query: { }})
-  const helloWithArgs = eden.hello.get.useQuery({ query: { text: 'client' }})
+  const helloNoArgs = eden.hello.get.useQuery()
+  const helloWithArgs = eden.hello.get.useQuery({ text: 'client' })
 </script>
 
 <div>

--- a/documentation/docs/eden-query/svelte/disabling.md
+++ b/documentation/docs/eden-query/svelte/disabling.md
@@ -26,11 +26,19 @@ head:
 import { Elysia, t } from 'elysia'
 import { batchPlugin } from '@ap0nia/eden-svelte-query'
 
-export const app = new Elysia().use(batchPlugin()).get('/user/:name', (context) => {
-  return {
-    name: context.params.name,
-  }
-})
+export const app = new Elysia().use(batchPlugin()).get(
+  '/user',
+  (context) => {
+    return {
+      name: context.query.name,
+    }
+  },
+  {
+    query: t.Object({
+      name: t.String(),
+    }),
+  },
+)
 
 export type App = typeof app
 ```
@@ -69,7 +77,7 @@ To disable queries, you can pass `skipToken` as the first argument to `useQuery`
 
   let name = ''
 
-  const result = eden.user[':name'].get.useQuery(name ? { params: { name } } : skipToken)
+  const result = eden.user.get.useQuery(name ? { name } : skipToken)
 </script>
 
 // ...

--- a/documentation/docs/eden-query/svelte/getQueryKey.md
+++ b/documentation/docs/eden-query/svelte/getQueryKey.md
@@ -90,7 +90,7 @@ See [TanStack/query#5111 (comment)](https://github.com/TanStack/query/issues/511
 
   const queryClient = useQueryClient()
 
-  const posts = eden.post.list.get.useQuery()
+  const posts = eden.post.list.get.createQuery()
 
   // See if a query is fetching
   const postListKey = getQueryKey(eden.post.list, undefined, 'query')

--- a/documentation/docs/eden-query/svelte/index.md
+++ b/documentation/docs/eden-query/svelte/index.md
@@ -86,7 +86,7 @@ export const eden = createEdenTreatySvelteQuery<App>()
 <script lang="ts">
   import { eden } from '../lib/eden'
 
-  const helloQuery = eden.hello.get.createQuery({ query: { name: 'Bob' } })
+  const helloQuery = eden.hello.get.createQuery({ name: 'Bob' })
   const goodbyeMutation = eden.goodbye.post.createMutation()
 </script>
 

--- a/documentation/docs/eden-query/svelte/reactive.md
+++ b/documentation/docs/eden-query/svelte/reactive.md
@@ -80,12 +80,12 @@ export type InferOutput = InferTreatyQueryOutput<App>
 <script lang="ts">
   import { eden, type InferInput } from '$lib/eden'
 
-  const input = writable<InferInput['post'][':id']['get']>({ params: { id: '' }})
+  const id = writable({ id: '' })
 
-  const post = eden.post[':id'].get.createQuery(input)
+  const post = eden.post(id).get.createQuery(input)
 </script>
 
-<input bind:value={$input.params.id}>
+<input bind:value={$id.id}>
 ```
 
 :::

--- a/documentation/docs/eden-query/svelte/setup.md
+++ b/documentation/docs/eden-query/svelte/setup.md
@@ -202,7 +202,7 @@ You can now use the eden-treaty React Query integration to call queries and muta
 <script lang="ts">
   import { eden } from '$lib/eden'
 
-  const userQuery = eden.user.get.useQuery({ query: { id: 'id_bilbo' }})
+  const userQuery = eden.user.get.useQuery({ id: 'id_bilbo' })
   const userCreator = eden.user.post.useMutation()
 </script>
 

--- a/documentation/docs/eden-query/svelte/useUtils.md
+++ b/documentation/docs/eden-query/svelte/useUtils.md
@@ -199,7 +199,7 @@ on the input passed to it to prevent unnecessary calls to the back end.
   const mutation = eden.post.edit.post.createMutation({
     onSuccess(input) {
       utils.post.all.invalidate()
-      utils.post[':id'].invalidate({ params: { id: input.id } }) // Will not invalidate queries for other id's 👍
+      utils.post({ id: input.id }).invalidate() // Will not invalidate queries for other id's 👍
     },
   })
 </script>
@@ -223,7 +223,7 @@ just one query.
   const mutation = eden.post.edit.post.createMutation({
     onSuccess(input) {
       utils.post.all.invalidate()
-      utils.post[':id'].invalidate({ params: { id: input.id } }) // Will not invalidate queries for other id's 👍
+      utils.post({ id: input.id }).invalidate() // Will not invalidate queries for other id's 👍
     },
   })
 
@@ -242,14 +242,14 @@ just one query.
   const invalidatePostById = () => {
     // 3️⃣
     // All queries in the post router with input {id:1} invalidated 📭
-    utils.post[':id'].invalidate({ id: 1 })
+    utils.post({ id: 1 }).invalidate()
   }
 
   // Example queries
   eden.user.all.get.createQuery() // Would only be validated by 1️⃣ only.
   eden.post.all.get.createQuery() // Would be invalidated by 1️⃣ & 2️⃣
-  eden.post[':id'].createQuery({ params: { id: 1 } }) // Would be invalidated by 1️⃣, 2️⃣ and 3️⃣
-  eden.post[':id'].createQuery({ params: { id: 2 } }) // would be invalidated by 1️⃣ and 2️⃣ but NOT 3️⃣!
+  eden.post({ id: 1 }).createQuery() // Would be invalidated by 1️⃣, 2️⃣ and 3️⃣
+  eden.post({ id: 2 }).createQuery() // would be invalidated by 1️⃣ and 2️⃣ but NOT 3️⃣!
 </script>
 ```
 

--- a/examples/eden-react-query-basic/server.ts
+++ b/examples/eden-react-query-basic/server.ts
@@ -112,6 +112,7 @@ const rootController = new Elysia()
       }),
     },
   )
+  .get('/products/:id', (context) => context.params.id)
 
 export const app = new Elysia({ prefix: '/api' })
   .use(cors())

--- a/examples/eden-react-query-basic/server.ts
+++ b/examples/eden-react-query-basic/server.ts
@@ -113,6 +113,36 @@ const rootController = new Elysia()
     },
   )
   .get('/products/:id', (context) => context.params.id)
+  .get('/nendoroid/:id/name', () => {
+    return 'Skadi'
+  })
+  .put(
+    '/nendoroid/:id',
+    (context) => {
+      return { status: 'OK', received: context.body }
+    },
+    {
+      body: t.Object({
+        name: t.String(),
+        from: t.String(),
+      }),
+    },
+  )
+  .patch(
+    '/nendoroid/:id',
+    (context) => {
+      return { status: 'OK', received: context.body }
+    },
+    {
+      query: t.Object({
+        location: t.String(),
+      }),
+      body: t.Object({
+        name: t.String(),
+        from: t.String(),
+      }),
+    },
+  )
 
 export const app = new Elysia({ prefix: '/api' })
   .use(cors())

--- a/examples/eden-react-query-basic/src/app.tsx
+++ b/examples/eden-react-query-basic/src/app.tsx
@@ -12,6 +12,7 @@ import HelloPreloadPage, { load as helloPreloadLoader } from './routes/hello-pre
 import InfinitePage from './routes/infinite/+page'
 import MutationPage from './routes/mutation/+page'
 import ReactiveInputPage from './routes/reactive-input/+page'
+import ReactiveParamsPage from './routes/reactive-params/+page'
 import UseQueriesPage from './routes/use-queries/+page'
 
 export function App() {
@@ -116,6 +117,10 @@ export function App() {
           {
             path: '/reactive-input',
             element: <ReactiveInputPage />,
+          },
+          {
+            path: '/reactive-params',
+            element: <ReactiveParamsPage />,
           },
           {
             path: '/infinite',

--- a/examples/eden-react-query-basic/src/app.tsx
+++ b/examples/eden-react-query-basic/src/app.tsx
@@ -11,6 +11,7 @@ import BatchPage from './routes/batch/+page'
 import HelloPreloadPage, { load as helloPreloadLoader } from './routes/hello-preload/+page'
 import InfinitePage from './routes/infinite/+page'
 import MutationPage from './routes/mutation/+page'
+import MutationQueryParamPage from './routes/mutation-query-params/+page'
 import ReactiveInputPage from './routes/reactive-input/+page'
 import ReactiveParamsPage from './routes/reactive-params/+page'
 import UseQueriesPage from './routes/use-queries/+page'
@@ -77,6 +78,14 @@ export function App() {
                     <Link to="/reactive-input">reactive input box</Link>
                   </li>
                   <li>
+                    <Link to="/reactive-params">reactive params</Link>
+                  </li>
+                  <li>
+                    <Link to="/mutation-query-params">
+                      mutation with query and path parameter input
+                    </Link>
+                  </li>
+                  <li>
                     <Link to="/abort">abort</Link>
                   </li>
                   <li>
@@ -109,6 +118,10 @@ export function App() {
           {
             path: '/mutation',
             element: <MutationPage />,
+          },
+          {
+            path: '/mutation-query-params',
+            element: <MutationQueryParamPage />,
           },
           {
             path: '/abort',

--- a/examples/eden-react-query-basic/src/routes/batch/+page.tsx
+++ b/examples/eden-react-query-basic/src/routes/batch/+page.tsx
@@ -1,9 +1,9 @@
 import { eden } from '../../lib/eden'
 
 export default function Page() {
-  const hello = eden.api.index.get.useQuery({})
+  const hello = eden.api.index.get.useQuery()
 
-  const bye = eden.api.bye.get.useQuery({})
+  const bye = eden.api.bye.get.useQuery()
 
   return (
     <main>

--- a/examples/eden-react-query-basic/src/routes/infinite/+page.tsx
+++ b/examples/eden-react-query-basic/src/routes/infinite/+page.tsx
@@ -1,22 +1,11 @@
 import { eden } from '../../lib/eden'
 
 export default function Page() {
-  const pages = eden.api.pages.get.useInfiniteQuery(
-    /**
-     * When the `query` property is defined, the `cursor` property will automatically be set
-     * for the request if it exists.
-     *
-     * Likewise if the `params` property was defined.
-     *
-     * @todo: Deterministically distinguish whether `query.cursor` or `params.cursor` should be set...
-     */
-    { query: {} },
-    {
-      getNextPageParam: (_lastPage, _allPages, lastPageParams, _allPageParams) => {
-        return (lastPageParams ?? 0) + 1
-      },
+  const pages = eden.api.pages.get.useInfiniteQuery(undefined, {
+    getNextPageParam: (_lastPage, _allPages, lastPageParams, _allPageParams) => {
+      return (lastPageParams ?? 0) + 1
     },
-  )
+  })
 
   const getNextPage = async () => {
     await pages.fetchNextPage()

--- a/examples/eden-react-query-basic/src/routes/mutation-query-params/+page.tsx
+++ b/examples/eden-react-query-basic/src/routes/mutation-query-params/+page.tsx
@@ -19,6 +19,10 @@ export default function Page() {
     withParamQuery.mutateAsync({ from: '', name: '' }, { query: { location: '' } })
   }
 
+  // const bruh = eden.useUtils()
+
+  // eden.api.nendoroid({ id: 1 })
+
   return (
     <main>
       <button onClick={handleParamMutation}>Params only</button>

--- a/examples/eden-react-query-basic/src/routes/mutation-query-params/+page.tsx
+++ b/examples/eden-react-query-basic/src/routes/mutation-query-params/+page.tsx
@@ -1,0 +1,28 @@
+import { eden } from '../../lib/eden'
+
+export default function Page() {
+  /**
+   * Path parameter is needed, but not query.
+   */
+  const withParam = eden.api.nendoroid({ id: 1895 }).put.useMutation()
+
+  /**
+   * Both query and path parameters are needed. Query is provided in `mutate` function.
+   */
+  const withParamQuery = eden.api.nendoroid({ id: 1895 }).patch.useMutation()
+
+  const handleParamMutation = async () => {
+    withParam.mutateAsync({ from: '', name: '' }, {})
+  }
+
+  const handleQueryParamMutation = async () => {
+    withParamQuery.mutateAsync({ from: '', name: '' }, { query: { location: '' } })
+  }
+
+  return (
+    <main>
+      <button onClick={handleParamMutation}>Params only</button>
+      <button onClick={handleQueryParamMutation}>Params with query</button>
+    </main>
+  )
+}

--- a/examples/eden-react-query-basic/src/routes/reactive-params/+page.tsx
+++ b/examples/eden-react-query-basic/src/routes/reactive-params/+page.tsx
@@ -8,7 +8,9 @@ export default function Page() {
     search: '',
   })
 
-  const names = eden.api.names.get.useQuery(input, {
+  const [id, setId] = useState(1)
+
+  const { data } = eden.api.products({ id }).get.useQuery(input, {
     /**
      * This prevents the data from disappearing briefly when loading up the next query.
      */
@@ -22,6 +24,10 @@ export default function Page() {
     })
   }
 
+  const handleIdChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setId(event.target.valueAsNumber)
+  }
+
   return (
     <main>
       <h1>Reactive Input</h1>
@@ -30,11 +36,7 @@ export default function Page() {
 
       <p>The developer can optimize this reactive input by using debounce...</p>
 
-      <ul>
-        {names.data?.map((name, index) => {
-          return <li key={index}>{name}</li>
-        })}
-      </ul>
+      <p>{data}</p>
 
       <label>
         <p>Search for a name by typing into the box</p>
@@ -44,6 +46,7 @@ export default function Page() {
           value={input.search}
           placeholder="Enter name here..."
         />
+        <input type="number" onChange={handleIdChange} />
       </label>
     </main>
   )

--- a/examples/eden-svelte-query-basic/src/routes/reactive-params/+page.svelte
+++ b/examples/eden-svelte-query-basic/src/routes/reactive-params/+page.svelte
@@ -5,12 +5,9 @@
 
   const input = writable<InferInput['api']['names']['get']['query']>({})
 
-  const names = eden.api.names.get.createQuery(input, {
-    /**
-     * This prevents the data from disappearing briefly when loading up the next query.
-     */
-    placeholderData: keepPreviousData,
-  })
+  const id = writable({ id: 1 })
+
+  const names = eden.api.todos(id).get.createQuery(input, { placeholderData: keepPreviousData })
 </script>
 
 <main>
@@ -29,5 +26,6 @@
   <label>
     <p>Search for a name by typing into the box</p>
     <input type="text" bind:value={$input.search} placeholder="Enter name here..." />
+    <input type="number" bind:value={$id.id} placeholder="Enter ID" />
   </label>
 </main>

--- a/examples/eden-svelte-query-basic/src/server.ts
+++ b/examples/eden-svelte-query-basic/src/server.ts
@@ -93,6 +93,7 @@ const rootController = new Elysia()
       body: t.String(),
     },
   )
+  .get('/todos/:id', (context) => context.params.id)
 
 export const app = new Elysia({ prefix: '/api' })
   .use(transformPlugin(SuperJSON))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elysiajs-eden",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "private": true,
   "description": "monorepo for eden, a fully type-safe Elysia.js client",
   "contributors": [

--- a/packages/eden-react-query/src/implementation/treaty/index.ts
+++ b/packages/eden-react-query/src/implementation/treaty/index.ts
@@ -209,7 +209,7 @@ export function createEdenTreatyReactQueryProxy<T extends AnyElysia = AnyElysia>
   const edenTreatyQueryProxy = new Proxy(() => {}, {
     get: (_target, path: string, _receiver): any => {
       const nextPaths = path === 'index' ? [...paths] : [...paths, path]
-      return createEdenTreatyReactQueryProxy(rootHooks, config, nextPaths)
+      return createEdenTreatyReactQueryProxy(rootHooks, config, nextPaths, pathParams)
     },
     apply: (_target, _thisArg, args) => {
       const pathsCopy = [...paths]

--- a/packages/eden-react-query/src/implementation/treaty/query-utils.ts
+++ b/packages/eden-react-query/src/implementation/treaty/query-utils.ts
@@ -322,7 +322,7 @@ export function createEdenTreatyQueryUtilsProxy<TRouter extends AnyElysia, TSSRC
       const queryType = getQueryType(hook)
 
       // The rest of the args are passed directly to the function.
-      const query = argsCopy.shift()
+      const firstArg = argsCopy.shift()
 
       const params: Record<string, any> = {}
 
@@ -332,7 +332,7 @@ export function createEdenTreatyQueryUtilsProxy<TRouter extends AnyElysia, TSSRC
         }
       }
 
-      const input = { query, params }
+      const input = { query: firstArg, params }
 
       const queryKey = getQueryKey(paths, input, queryType)
 
@@ -394,7 +394,7 @@ export function createEdenTreatyQueryUtilsProxy<TRouter extends AnyElysia, TSSRC
         }
 
         case 'setMutationDefaults': {
-          return context.setMutationDefaults(getMutationKey(paths), input)
+          return context.setMutationDefaults(getMutationKey(paths), firstArg)
         }
 
         case 'getMutationDefaults': {

--- a/packages/eden-react-query/src/implementation/treaty/query-utils.ts
+++ b/packages/eden-react-query/src/implementation/treaty/query-utils.ts
@@ -43,6 +43,11 @@ import type {
 } from '../../integration/internal/infinite-query'
 import { parsePathsAndMethod } from '../../integration/internal/parse-paths-and-method'
 import {
+  type ExtractEdenTreatyRouteParams,
+  type ExtractEdenTreatyRouteParamsInput,
+  getPathParam,
+} from '../../integration/internal/path-params'
+import {
   type EdenQueryKey,
   getMutationKey,
   getQueryKey,
@@ -64,11 +69,16 @@ export type EdenTreatyQueryContextProps<
 export type EdenTreatyQueryUtilsProxy<
   TSchema extends Record<string, any>,
   TPath extends any[] = [],
+  TRouteParams = ExtractEdenTreatyRouteParams<TSchema>,
 > = EdenTreatyQueryUtilsUniversalUtils & {
   [K in keyof TSchema]: TSchema[K] extends RouteSchema
     ? EdenTreatyQueryUtilsMapping<TSchema[K], TPath, K>
     : EdenTreatyQueryUtilsProxy<TSchema[K], [...TPath, K]>
-}
+} & ({} extends TRouteParams
+    ? {}
+    : (
+        params: ExtractEdenTreatyRouteParamsInput<TRouteParams>,
+      ) => EdenTreatyQueryUtilsProxy<TSchema[Extract<keyof TRouteParams, keyof TSchema>], TPath>)
 
 type EdenTreatyQueryUtilsMapping<
   TRoute extends RouteSchema,
@@ -82,12 +92,12 @@ type EdenTreatyQueryUtilsMapping<
         : {})
   : TMethod extends HttpMutationMethod
     ? EdenQueryUtilsMutationUtils<TRoute, TPath>
-    : never
+    : `Unknown HTTP Method: ${TMethod & string}`
 
 export type EdenTreatyQueryUtilsQueryUtils<
   TRoute extends RouteSchema,
   TPath extends any[] = [],
-  TInput = InferRouteOptions<TRoute>,
+  TInput = InferRouteOptions<TRoute>['query'],
   TOutput = InferRouteOutput<TRoute>,
   TError = InferRouteError<TRoute>,
   TKey extends QueryKey = EdenQueryKey<TPath, TInput>,
@@ -155,7 +165,7 @@ export type EdenTreatyQueryUtilsQueryUtils<
 export type EdenTreatyQueryUtilsInfiniteUtils<
   TRoute extends RouteSchema,
   TPath extends any[] = [],
-  TInput = InferRouteOptions<TRoute, ReservedInfiniteQueryKeys>,
+  TInput = InferRouteOptions<TRoute, ReservedInfiniteQueryKeys>['query'],
   TOutput = InferRouteOutput<TRoute>,
   TError = InferRouteError<TRoute>,
   TKey extends QueryKey = EdenQueryKey<TPath, TInput>,
@@ -262,14 +272,23 @@ export function createEdenTreatyQueryUtilsProxy<TRouter extends AnyElysia, TSSRC
   context: EdenContextState<TRouter, TSSRContext>,
   config?: EdenQueryConfig<TRouter>,
   originalPaths: string[] = [],
+  pathParams: Record<string, any>[] = [],
 ): EdenTreatyQueryUtils<TRouter, TSSRContext> {
   const proxy = new Proxy(() => {}, {
     get: (_target, path: string, _receiver) => {
       const nextPaths = path === 'index' ? [...originalPaths] : [...originalPaths, path]
-      return createEdenTreatyQueryUtilsProxy(context, config, nextPaths)
+      return createEdenTreatyQueryUtilsProxy(context, config, nextPaths, pathParams)
     },
-    apply: (_target, _thisArg, argArray) => {
-      const argsCopy = [...argArray]
+    apply: (_target, _thisArg, args) => {
+      const pathParam = getPathParam(args)
+
+      if (pathParam?.key != null) {
+        const allPathParams = [...pathParams, pathParam.param]
+        const pathsWithParams = [...originalPaths, `:${pathParam.key}`]
+        return createEdenTreatyQueryUtilsProxy(context, config, pathsWithParams, allPathParams)
+      }
+
+      const argsCopy = [...args]
 
       /**
        * @example ['api', 'hello', 'get', 'invalidate']
@@ -302,7 +321,18 @@ export function createEdenTreatyQueryUtilsProxy<TRouter extends AnyElysia, TSSRC
 
       const queryType = getQueryType(hook)
 
-      const input = argsCopy.shift() // args can now be spread when input removed
+      // The rest of the args are passed directly to the function.
+      const query = argsCopy.shift()
+
+      const params: Record<string, any> = {}
+
+      for (const param of pathParams) {
+        for (const key in param) {
+          params[key] = param[key]
+        }
+      }
+
+      const input = { query, params }
 
       const queryKey = getQueryKey(paths, input, queryType)
 

--- a/packages/eden-react-query/src/implementation/treaty/root-hooks.tsx
+++ b/packages/eden-react-query/src/implementation/treaty/root-hooks.tsx
@@ -358,6 +358,7 @@ export function createEdenTreatyQueryRootHooks<
   }
 }
 
-export type EdenTreatyQueryRootHooks<TElysia extends AnyElysia, TSSRContext = unknown> = ReturnType<
-  typeof createEdenTreatyQueryRootHooks<TElysia, TSSRContext>
->
+export type EdenTreatyQueryRootHooks<
+  TElysia extends AnyElysia = AnyElysia,
+  TSSRContext = unknown,
+> = ReturnType<typeof createEdenTreatyQueryRootHooks<TElysia, TSSRContext>>

--- a/packages/eden-react-query/src/implementation/treaty/root-hooks.tsx
+++ b/packages/eden-react-query/src/implementation/treaty/root-hooks.tsx
@@ -6,8 +6,10 @@ import {
   type HttpBatchLinkOptions,
   httpLink,
   type HTTPLinkOptions,
+  type InferRouteOptions,
 } from '@ap0nia/eden'
 import {
+  type SkipToken,
   useInfiniteQuery as __useInfiniteQuery,
   useQueries as __useQueries,
   useQuery as __useQuery,
@@ -152,7 +154,7 @@ export function createEdenTreatyQueryRootHooks<
 
   const useQuery = (
     originalPaths: readonly string[],
-    input: any,
+    input?: InferRouteOptions | SkipToken,
     options?: EdenUseQueryOptions<unknown, unknown, TError>,
   ): EdenUseQueryResult<unknown, TError> => {
     const context = useRawContext()
@@ -176,7 +178,7 @@ export function createEdenTreatyQueryRootHooks<
 
   const useSuspenseQuery = (
     originalPaths: readonly string[],
-    input: any,
+    input: InferRouteOptions,
     options?: EdenUseSuspenseQueryOptions<unknown, unknown, TError>,
   ): EdenUseSuspenseQueryResult<unknown, TError> => {
     const context = useRawContext()
@@ -200,7 +202,7 @@ export function createEdenTreatyQueryRootHooks<
 
   const useInfiniteQuery = (
     originalPaths: readonly string[],
-    input: any,
+    input?: InferRouteOptions | SkipToken,
     options?: EdenUseInfiniteQueryOptions<unknown, unknown, TError>,
   ): EdenUseInfiniteQueryResult<unknown, TError, unknown> => {
     const context = useRawContext()
@@ -224,7 +226,7 @@ export function createEdenTreatyQueryRootHooks<
 
   const useSuspenseInfiniteQuery = (
     originalPaths: readonly string[],
-    input: any,
+    input: InferRouteOptions,
     options?: EdenUseSuspenseInfiniteQueryOptions<unknown, unknown, TError>,
   ): EdenUseSuspenseInfiniteQueryResult<unknown, TError, unknown> => {
     const context = useRawContext()
@@ -287,13 +289,14 @@ export function createEdenTreatyQueryRootHooks<
 
   const useMutation = (
     originalPaths: readonly string[],
+    input?: InferRouteOptions,
     options?: EdenUseMutationOptions<unknown, TError, unknown, unknown>,
   ): EdenUseMutationResult<unknown, TError, unknown, unknown, unknown> => {
     const context = useRawContext()
 
     const parsed = parsePathsAndMethod(originalPaths)
 
-    const mutationOptions = getEdenUseMutationOptions(parsed, context, options, config)
+    const mutationOptions = getEdenUseMutationOptions(parsed, context, input, options, config)
 
     type HookResult = EdenUseMutationResult<any, any, any, any, any>
 

--- a/packages/eden-react-query/src/implementation/treaty/root-hooks.tsx
+++ b/packages/eden-react-query/src/implementation/treaty/root-hooks.tsx
@@ -159,12 +159,7 @@ export function createEdenTreatyQueryRootHooks<
 
     const parsed = parsePathsAndMethod(originalPaths)
 
-    /**
-     * The outer proxy will include all the path parameters, so this input is only the query.
-     */
-    const query = { query: input }
-
-    const queryOptions = edenUseQueryOptions(parsed, context, query, options, config)
+    const queryOptions = edenUseQueryOptions(parsed, context, input, options, config)
 
     type HookResult = EdenUseQueryResult<any, TError>
 
@@ -188,12 +183,7 @@ export function createEdenTreatyQueryRootHooks<
 
     const parsed = parsePathsAndMethod(originalPaths)
 
-    /**
-     * The outer proxy will include all the path parameters, so this input is only the query.
-     */
-    const query = { query: input }
-
-    const queryOptions = edenUseQueryOptions(parsed, context, query, options, config)
+    const queryOptions = edenUseQueryOptions(parsed, context, input, options, config)
 
     type HookResult = EdenUseQueryResult<any, TError>
 
@@ -217,12 +207,7 @@ export function createEdenTreatyQueryRootHooks<
 
     const parsed = parsePathsAndMethod(originalPaths)
 
-    /**
-     * The outer proxy will include all the path parameters, so this input is only the query.
-     */
-    const query = { query: input }
-
-    const queryOptions = edenUseInfiniteQueryOptions(parsed, context, query, options, config)
+    const queryOptions = edenUseInfiniteQueryOptions(parsed, context, input, options, config)
 
     type HookResult = EdenUseInfiniteQueryResult<unknown, TError, unknown>
 
@@ -246,12 +231,7 @@ export function createEdenTreatyQueryRootHooks<
 
     const parsed = parsePathsAndMethod(originalPaths)
 
-    /**
-     * The outer proxy will include all the path parameters, so this input is only the query.
-     */
-    const query = { query: input }
-
-    const queryOptions = edenUseInfiniteQueryOptions(parsed, context, query, options, config)
+    const queryOptions = edenUseInfiniteQueryOptions(parsed, context, input, options, config)
 
     type HookResult = EdenUseInfiniteQueryResult<unknown, TError, unknown>
 

--- a/packages/eden-react-query/src/integration/hooks/use-infinite-query.ts
+++ b/packages/eden-react-query/src/integration/hooks/use-infinite-query.ts
@@ -41,10 +41,11 @@ export type EdenUseInfiniteQuerySuccessResult<TData, TError, TInput> = WithEdenQ
 export type EdenUseInfiniteQuery<
   TRoute extends RouteSchema,
   _TPath extends any[] = [],
-  TInput = InferRouteOptions<TRoute>,
+  // The exposed public type for `useInfiniteQuery` only needs the `query` from the input options.
+  TInput = InferRouteOptions<TRoute>['query'],
   TOutput = InferRouteOutput<TRoute>,
   TError = InferRouteError<TRoute>,
-  TInfiniteInput = InferRouteOptions<TRoute, ReservedInfiniteQueryKeys>,
+  TInfiniteInput = InferRouteOptions<TRoute, ReservedInfiniteQueryKeys>['query'],
 > = (
   input: TInfiniteInput | SkipToken,
   options: EdenUseInfiniteQueryOptions<TInput, TOutput, TError>,
@@ -53,7 +54,8 @@ export type EdenUseInfiniteQuery<
 export function edenUseInfiniteQueryOptions(
   parsedPathAndMethod: ParsedPathAndMethod,
   context: EdenContextState<any, any>,
-  input?: any,
+  // The helper `useInfiniteQueryOptions` receives the entire options object.
+  input?: InferRouteOptions | SkipToken,
   options?: EdenUseInfiniteQueryOptions<unknown, unknown, any>,
   config?: any,
 ): UseInfiniteQueryOptions {
@@ -61,13 +63,13 @@ export function edenUseInfiniteQueryOptions(
 
   const { paths, path, method } = parsedPathAndMethod
 
-  const queryKey = getQueryKey(paths, input, 'infinite')
+  const isInputSkipToken = input === skipToken && typeof input !== 'object'
+
+  const queryKey = getQueryKey(paths, isInputSkipToken ? undefined : input, 'infinite')
 
   const defaultOptions = queryClient.getQueryDefaults(queryKey)
 
   const initialQueryOptions = { ...defaultOptions, ...options }
-
-  const isInputSkipToken = input === skipToken
 
   if (isServerQuery(ssrState, options, defaultOptions, isInputSkipToken, queryClient, queryKey)) {
     void prefetchInfiniteQuery(queryKey, initialQueryOptions as any)

--- a/packages/eden-react-query/src/integration/hooks/use-infinite-query.ts
+++ b/packages/eden-react-query/src/integration/hooks/use-infinite-query.ts
@@ -11,7 +11,7 @@ import type { RouteSchema } from 'elysia'
 
 import { type EdenContextState, useSSRQueryOptionsIfNeeded } from '../../context'
 import type { DistributiveOmit } from '../../utils/types'
-import type { ExtractCursorType, ReservedInfiniteQueryKeys } from '../internal/infinite-query'
+import type { ExtractQueryCursor, ReservedInfiniteQueryKeys } from '../internal/infinite-query'
 import type { ParsedPathAndMethod } from '../internal/parse-paths-and-method'
 import type { EdenQueryBaseOptions } from '../internal/query-base-options'
 import type { WithEdenQueryExtension } from '../internal/query-hook-extension'
@@ -20,20 +20,23 @@ import { isServerQuery } from './use-query'
 
 export interface EdenUseInfiniteQueryOptions<TInput, TOutput, TError>
   extends DistributiveOmit<
-      UseInfiniteQueryOptions<TOutput, TError, TOutput, TOutput, any, ExtractCursorType<TInput>>,
+      UseInfiniteQueryOptions<TOutput, TError, TOutput, TOutput, any, ExtractQueryCursor<TInput>>,
       'queryKey' | 'initialPageParam'
     >,
     EdenQueryBaseOptions {
-  initialCursor?: ExtractCursorType<TInput>
+  initialCursor?: ExtractQueryCursor<TInput>
 }
 
 export type EdenUseInfiniteQueryResult<TData, TError, TInput> = WithEdenQueryExtension<
-  UseInfiniteQueryResult<InfiniteData<TData, NonNullable<ExtractCursorType<TInput>> | null>, TError>
+  UseInfiniteQueryResult<
+    InfiniteData<TData, NonNullable<ExtractQueryCursor<TInput>> | null>,
+    TError
+  >
 >
 
 export type EdenUseInfiniteQuerySuccessResult<TData, TError, TInput> = WithEdenQueryExtension<
   InfiniteQueryObserverSuccessResult<
-    InfiniteData<TData, NonNullable<ExtractCursorType<TInput>> | null>,
+    InfiniteData<TData, NonNullable<ExtractQueryCursor<TInput>> | null>,
     TError
   >
 >
@@ -47,7 +50,7 @@ export type EdenUseInfiniteQuery<
   TError = InferRouteError<TRoute>,
   TInfiniteInput = InferRouteOptions<TRoute, ReservedInfiniteQueryKeys>['query'],
 > = (
-  input: TInfiniteInput | SkipToken,
+  input: {} extends TInfiniteInput ? void | TInfiniteInput : SkipToken,
   options: EdenUseInfiniteQueryOptions<TInput, TOutput, TError>,
 ) => EdenUseInfiniteQueryResult<TOutput, TError, TInput>
 

--- a/packages/eden-react-query/src/integration/hooks/use-mutation.ts
+++ b/packages/eden-react-query/src/integration/hooks/use-mutation.ts
@@ -46,7 +46,8 @@ export type EdenUseMutation<
   TRoute extends RouteSchema,
   _TPath extends any[] = [],
   TVariables = InferRouteBody<TRoute>,
-  TInput = InferRouteOptions<TRoute>,
+  TInput = Partial<Pick<InferRouteOptions<TRoute>, 'params'>> &
+    Omit<InferRouteOptions<TRoute>, 'params'>,
   TData = InferRouteOutput<TRoute>,
   TError = InferRouteError<TRoute>,
 > = <TContext = unknown>(
@@ -142,6 +143,8 @@ export function useEdenMutation<
 export function getEdenUseMutationOptions(
   parsedPathsAndMethod: ParsedPathAndMethod,
   context: EdenContextState<any, any>,
+  // Default input.
+  input?: InferRouteOptions,
   options?: EdenUseMutationOptions<any, any, any>,
   config?: any,
 ): UseMutationOptions {
@@ -161,9 +164,11 @@ export function getEdenUseMutationOptions(
     mutationFn: async (variables: any = {}) => {
       const { body, options } = variables as EdenUseMutationVariables
 
+      const resolvedOptions = { ...input, ...options }
+
       const params: EdenRequestParams = {
         ...config,
-        options,
+        options: resolvedOptions,
         body,
         path,
         method,

--- a/packages/eden-react-query/src/integration/hooks/use-query.ts
+++ b/packages/eden-react-query/src/integration/hooks/use-query.ts
@@ -55,7 +55,8 @@ export type EdenDefinedUseQueryResult<TData, TError> = WithEdenQueryExtension<
 export interface EdenUseQuery<
   TRoute extends RouteSchema,
   _TPath extends any[] = [],
-  TInput = InferRouteOptions<TRoute>,
+  // The publicly exposed `useQuery` hook only accepts the `query` object.
+  TInput = InferRouteOptions<TRoute>['query'],
   TOutput = InferRouteOutput<TRoute>,
   TError = InferRouteError<TRoute>,
 > {
@@ -102,7 +103,8 @@ export function isServerQuery(
 export function edenUseQueryOptions(
   parsedPathAndMethod: ParsedPathAndMethod,
   context: EdenContextState<any, any>,
-  input?: any,
+  // The internal helper to `useQueryOptions` receives the entire input object, including `query` and `params`.
+  input?: InferRouteOutput | SkipToken,
   options?: EdenUseQueryOptions<unknown, unknown, any>,
   config?: EdenQueryConfig,
 ): UseQueryOptions {
@@ -110,11 +112,11 @@ export function edenUseQueryOptions(
 
   const { paths, path, method } = parsedPathAndMethod
 
-  const queryKey = getQueryKey(paths, input, 'query')
+  const isInputSkipToken = input === skipToken && typeof input !== 'object'
+
+  const queryKey = getQueryKey(paths, isInputSkipToken ? undefined : input, 'query')
 
   const defaultOptions = queryClient.getQueryDefaults(queryKey)
-
-  const isInputSkipToken = input === skipToken
 
   if (isServerQuery(ssrState, options, defaultOptions, isInputSkipToken, queryClient, queryKey)) {
     void prefetchQuery(queryKey, options)

--- a/packages/eden-react-query/src/integration/hooks/use-query.ts
+++ b/packages/eden-react-query/src/integration/hooks/use-query.ts
@@ -104,7 +104,7 @@ export function edenUseQueryOptions(
   parsedPathAndMethod: ParsedPathAndMethod,
   context: EdenContextState<any, any>,
   // The internal helper to `useQueryOptions` receives the entire input object, including `query` and `params`.
-  input?: InferRouteOutput | SkipToken,
+  input?: InferRouteOptions | SkipToken,
   options?: EdenUseQueryOptions<unknown, unknown, any>,
   config?: EdenQueryConfig,
 ): UseQueryOptions {

--- a/packages/eden-react-query/src/integration/hooks/use-suspense-infinite-query.ts
+++ b/packages/eden-react-query/src/integration/hooks/use-suspense-infinite-query.ts
@@ -43,7 +43,7 @@ export type EdenUseSuspenseInfiniteQueryResult<TData, TError, TInput> = [
 export type EdenUseSuspenseInfiniteQuery<
   TRoute extends RouteSchema,
   _TPath extends any[] = [],
-  TInput = InferRouteOptions<TRoute>,
+  TInput = InferRouteOptions<TRoute>['query'],
   TOutput = InferRouteOutput<TRoute>,
   TError = InferRouteError<TRoute>,
 > = (

--- a/packages/eden-react-query/src/integration/hooks/use-suspense-query.ts
+++ b/packages/eden-react-query/src/integration/hooks/use-suspense-query.ts
@@ -21,7 +21,7 @@ export type EdenUseSuspenseQueryResult<TData, TError> = [
 export type EdenUseSuspenseQuery<
   TRoute extends RouteSchema,
   _TPath extends any[] = [],
-  TInput = InferRouteOptions<TRoute>,
+  TInput = InferRouteOptions<TRoute>['query'],
   TOutput = InferRouteOutput<TRoute>,
   TError = InferRouteError<TRoute>,
 > = (

--- a/packages/eden-react-query/src/integration/internal/infinite-query.ts
+++ b/packages/eden-react-query/src/integration/internal/infinite-query.ts
@@ -15,3 +15,5 @@ export type ReservedInfiniteQueryKeys = InfiniteCursorKey | 'direction'
  */
 export type ExtractCursorType<T> =
   T extends Record<string, any> ? (T['params'] & T['query'])['cursor'] : unknown
+
+export type ExtractQueryCursor<T> = T extends Record<string, any> ? T['cursor'] : unknown

--- a/packages/eden-react-query/src/integration/internal/path-params.ts
+++ b/packages/eden-react-query/src/integration/internal/path-params.ts
@@ -1,0 +1,46 @@
+/**
+ *
+ * An eden-treaty proxy may look like these examples:
+ *
+ * eden.api.products.get({ limit: 5 })
+ * eden.api.product({ id: 'product-id' }).details.get({ limit: 5 })
+ *
+ * In the first example, the proxy is called like a function at the very end, so it is trivial
+ * to infer that the arguments are the query parameters for fetch request.
+ *
+ * In the second example, there are two function calls, and we need to heuristically determine whether
+ * it is a function call to insert a path parameter, or the actual end.
+ *
+ * Heuristic: A path parameter function call needs exactly one object with exactly one key passed as an argument.
+ */
+export function getPathParam(args: unknown[]) {
+  if (args.length !== 1) {
+    return
+  }
+
+  const argument = args[0]
+
+  if (argument == null || typeof argument !== 'object') {
+    return
+  }
+
+  const argumentKeys = Object.keys(argument)
+
+  const pathParam = argumentKeys[0]
+
+  if (argumentKeys.length !== 1 || pathParam == null) {
+    return
+  }
+
+  return { param: argument as any, key: argumentKeys[0] }
+}
+
+export type ExtractEdenTreatyRouteParams<T> = {
+  [K in keyof T as K extends `:${string}` ? K : never]: T[K]
+}
+
+export type ExtractEdenTreatyRouteParamsInput<T> = {
+  [K in keyof T as K extends `:${infer TParam}` ? TParam : never]: string | number
+}
+
+export type ExtractRouteParam<T> = T extends `:${infer TParam}` ? TParam : T

--- a/packages/eden-react-query/src/utils/literal-union.ts
+++ b/packages/eden-react-query/src/utils/literal-union.ts
@@ -1,0 +1,7 @@
+/**
+ * Allows you to get autocomplete even when allowing arbitrary values.
+ *
+ * For example, `'a' | 'b' | LiteralUnion<string>` allows any arbitrary string, but you
+ * get autocomplete for the value.
+ */
+export type LiteralUnion<T> = T & { _?: any }

--- a/packages/eden-react-query/src/utils/path-param.ts
+++ b/packages/eden-react-query/src/utils/path-param.ts
@@ -41,16 +41,17 @@ export function getPathParam(args: unknown[]) {
 }
 
 /**
- * The positional index of the `input` provided to root query hooks.
- *
- * `undefined` if the function does not receive `input`.
+ * Some hooks have `input` provided as the first argument to the root hook.
+ * If this is the case, then {@link mutateArgs} needs to ensure that any
+ * accummulated path parameters are included.
  */
-const inputPositions: Partial<
-  Record<keyof EdenTreatyQueryRootHooks | LiteralUnion<string>, number>
-> = {
-  useQuery: 0,
-  useInfiniteQuery: 0,
-}
+const hooksWithInput: (keyof EdenTreatyQueryRootHooks | LiteralUnion<string>)[] = [
+  'useQuery',
+  'useInfiniteQuery',
+  'useSuspenseQuery',
+  'useSuspenseInfiniteQuery',
+  'useMutation',
+]
 
 /**
  * Directly mutate the arguments passed to the root hooks.
@@ -62,13 +63,11 @@ export function mutateArgs(
   args: unknown[],
   params: Record<string, any>[],
 ) {
-  const inputPosition = inputPositions[hook]
-
-  if (inputPosition == null) {
+  if (!hooksWithInput.includes(hook)) {
     return args
   }
 
-  const query = args[inputPosition]
+  const query = args[0]
 
   if (query == null && params.length === 0) {
     return args
@@ -87,7 +86,7 @@ export function mutateArgs(
     query,
   }
 
-  args[inputPosition] = resolvedInput
+  args[0] = resolvedInput
 
   return args
 }

--- a/packages/eden-react-query/src/utils/path-param.ts
+++ b/packages/eden-react-query/src/utils/path-param.ts
@@ -17,7 +17,7 @@ import type { LiteralUnion } from './literal-union'
  * Heuristic: A path parameter function call needs exactly one object with exactly one key passed as an argument.
  */
 export function getPathParam(args: unknown[]) {
-  if (args.length === 0) {
+  if (args.length !== 1) {
     return
   }
 
@@ -48,8 +48,8 @@ export function getPathParam(args: unknown[]) {
 const inputPositions: Partial<
   Record<keyof EdenTreatyQueryRootHooks | LiteralUnion<string>, number>
 > = {
-  createQuery: 0,
-  createInfiniteQuery: 0,
+  useQuery: 0,
+  useInfiniteQuery: 0,
 }
 
 /**

--- a/packages/eden-svelte-query/src/implementation/treaty/index.ts
+++ b/packages/eden-svelte-query/src/implementation/treaty/index.ts
@@ -127,7 +127,7 @@ export type EdenTreatySvelteQueryRouteHooks<
     ? EdenTreatyMutationMapping<TRoute, TPath>
     : TMethod extends HttpSubscriptionMethod
       ? EdenTreatySubscriptionMapping<TRoute, TPath>
-      : never
+      : `Unknown HTTP Method: ${TMethod & string}`
 
 /**
  * Available hooks assuming that the route supports createQuery.
@@ -209,6 +209,13 @@ export function createEdenTreatySvelteQueryProxy<T extends AnyElysia = AnyElysia
         const allPathParams = [...pathParams, pathParam.param]
         const pathsWithParams = [...paths, `:${pathParam.key}`]
         return createEdenTreatySvelteQueryProxy(rootHooks, config, pathsWithParams, allPathParams)
+      }
+
+      // There is no option to pass in input from the public exposed hook,
+      // but the internal root `createMutation` hook expects input as the first argument.
+      // Add an empty element at the front representing "input".
+      if (hook === 'createMutation') {
+        args.unshift(undefined)
       }
 
       const modifiedArgs = mutateArgs(hook, args, pathParams)

--- a/packages/eden-svelte-query/src/implementation/treaty/root-hooks.ts
+++ b/packages/eden-svelte-query/src/implementation/treaty/root-hooks.ts
@@ -12,6 +12,7 @@ import {
   createInfiniteQuery as __createInfiniteQuery,
   createQueries as __createQueries,
   createQuery as __createQuery,
+  type SkipToken,
   type StoreOrVal,
   useQueryClient,
 } from '@tanstack/svelte-query'
@@ -122,7 +123,7 @@ export function createEdenTreatyQueryRootHooks<
 
   const createQuery = (
     originalPaths: readonly string[],
-    input: StoreOrVal<InferRouteOptions>,
+    input?: StoreOrVal<InferRouteOptions | SkipToken>,
     options?: StoreOrVal<EdenCreateQueryOptions<unknown, unknown, TError>>,
   ): EdenCreateQueryResult<unknown, TError> => {
     const context = getRawContext()
@@ -176,8 +177,8 @@ export function createEdenTreatyQueryRootHooks<
 
   const createInfiniteQuery = (
     originalPaths: readonly string[],
-    input: StoreOrVal<InferRouteOptions>,
-    options: StoreOrVal<EdenCreateInfiniteQueryOptions<unknown, unknown, TError>>,
+    input?: StoreOrVal<InferRouteOptions | SkipToken>,
+    options?: StoreOrVal<EdenCreateInfiniteQueryOptions<unknown, unknown, TError>>,
   ): EdenCreateInfiniteQueryResult<unknown, TError, unknown> => {
     const context = getRawContext()
 
@@ -217,6 +218,7 @@ export function createEdenTreatyQueryRootHooks<
 
   const createMutation = (
     originalPaths: readonly string[],
+    input?: InferRouteOptions,
     options?: StoreOrVal<EdenCreateMutationOptions<unknown, TError, unknown, unknown>>,
   ): EdenCreateMutationResult<unknown, TError, unknown, unknown, unknown> => {
     const context = getRawContext()
@@ -230,7 +232,7 @@ export function createEdenTreatyQueryRootHooks<
     type HookResult = EdenCreateMutationResult<unknown, TError, unknown, unknown, any>
 
     if (!isStore(options)) {
-      const mutationOptions = edenCreateMutationOptions(parsed, context, options, config)
+      const mutationOptions = edenCreateMutationOptions(parsed, context, input, options, config)
 
       const hook = createEdenMutation(mutationOptions, queryClient) as HookResult
 
@@ -242,7 +244,7 @@ export function createEdenTreatyQueryRootHooks<
     const optionsStore = isStore(options) ? options : readable(options)
 
     const mutationOptionsStore = derived(optionsStore, ($options) => {
-      const mutationOptions = edenCreateMutationOptions(parsed, context, $options, config)
+      const mutationOptions = edenCreateMutationOptions(parsed, context, input, $options, config)
       return mutationOptions
     })
 

--- a/packages/eden-svelte-query/src/implementation/treaty/root-hooks.ts
+++ b/packages/eden-svelte-query/src/implementation/treaty/root-hooks.ts
@@ -6,6 +6,7 @@ import {
   type HttpBatchLinkOptions,
   httpLink,
   type HTTPLinkOptions,
+  type InferRouteOptions,
 } from '@ap0nia/eden'
 import {
   createInfiniteQuery as __createInfiniteQuery,
@@ -121,7 +122,7 @@ export function createEdenTreatyQueryRootHooks<
 
   const createQuery = (
     originalPaths: readonly string[],
-    input: StoreOrVal<any>,
+    input: StoreOrVal<InferRouteOptions>,
     options?: StoreOrVal<EdenCreateQueryOptions<unknown, unknown, TError>>,
   ): EdenCreateQueryResult<unknown, TError> => {
     const context = getRawContext()
@@ -175,7 +176,7 @@ export function createEdenTreatyQueryRootHooks<
 
   const createInfiniteQuery = (
     originalPaths: readonly string[],
-    input: StoreOrVal<any>,
+    input: StoreOrVal<InferRouteOptions>,
     options: StoreOrVal<EdenCreateInfiniteQueryOptions<unknown, unknown, TError>>,
   ): EdenCreateInfiniteQueryResult<unknown, TError, unknown> => {
     const context = getRawContext()
@@ -268,6 +269,7 @@ export function createEdenTreatyQueryRootHooks<
   }
 }
 
-export type EdenTreatyQueryRootHooks<TElysia extends AnyElysia, TSSRContext = unknown> = ReturnType<
-  typeof createEdenTreatyQueryRootHooks<TElysia, TSSRContext>
->
+export type EdenTreatyQueryRootHooks<
+  TElysia extends AnyElysia = AnyElysia,
+  TSSRContext = unknown,
+> = ReturnType<typeof createEdenTreatyQueryRootHooks<TElysia, TSSRContext>>

--- a/packages/eden-svelte-query/src/integration/hooks/create-infinite-query.ts
+++ b/packages/eden-svelte-query/src/integration/hooks/create-infinite-query.ts
@@ -61,7 +61,7 @@ export type EdenCreateInfiniteQuery<
   TInput = InferRouteOptions<TRoute>['query'],
   TOutput = InferRouteOutput<TRoute>,
   TError = InferRouteError<TRoute>,
-  TInfiniteInput = InferRouteOptions<TRoute, ReservedInfiniteQueryKeys>,
+  TInfiniteInput = InferRouteOptions<TRoute, ReservedInfiniteQueryKeys>['query'],
 > = (
   input: StoreOrVal<
     ({} extends TInfiniteInput ? void | TInfiniteInput : TInfiniteInput) | SkipToken

--- a/packages/eden-svelte-query/src/integration/hooks/create-infinite-query.ts
+++ b/packages/eden-svelte-query/src/integration/hooks/create-infinite-query.ts
@@ -18,7 +18,7 @@ import type { RouteSchema } from 'elysia'
 import type { EdenQueryConfig } from '../../config'
 import type { EdenContextState } from '../../context'
 import type { DistributiveOmit } from '../../utils/types'
-import type { ExtractCursorType } from '../internal/infinite-query'
+import type { ExtractQueryCursor, ReservedInfiniteQueryKeys } from '../internal/infinite-query'
 import type { ParsedPathAndMethod } from '../internal/parse-paths-and-method'
 import type { EdenQueryBaseOptions } from '../internal/query-base-options'
 import type { WithEdenQueryExtension } from '../internal/query-hook-extension'
@@ -26,23 +26,30 @@ import { getQueryKey } from '../internal/query-key'
 
 export interface EdenCreateInfiniteQueryOptions<TInput, TOutput, TError>
   extends DistributiveOmit<
-      CreateInfiniteQueryOptions<TOutput, TError, TOutput, TOutput, any, ExtractCursorType<TInput>>,
+      CreateInfiniteQueryOptions<
+        TOutput,
+        TError,
+        TOutput,
+        TOutput,
+        any,
+        ExtractQueryCursor<TInput>
+      >,
       'queryKey' | 'initialPageParam'
     >,
     EdenQueryBaseOptions {
-  initialCursor?: ExtractCursorType<TInput>
+  initialCursor?: ExtractQueryCursor<TInput>
 }
 
 export type EdenCreateInfiniteQueryResult<TData, TError, TInput> = WithEdenQueryExtension<
   CreateInfiniteQueryResult<
-    InfiniteData<TData, NonNullable<ExtractCursorType<TInput>> | null>,
+    InfiniteData<TData, NonNullable<ExtractQueryCursor<TInput>> | null>,
     TError
   >
 >
 
 export type EdenCreateInfiniteQuerySuccessResult<TData, TError, TInput> = WithEdenQueryExtension<
   InfiniteQueryObserverSuccessResult<
-    InfiniteData<TData, NonNullable<ExtractCursorType<TInput>> | null>,
+    InfiniteData<TData, NonNullable<ExtractQueryCursor<TInput>> | null>,
     TError
   >
 >
@@ -50,18 +57,23 @@ export type EdenCreateInfiniteQuerySuccessResult<TData, TError, TInput> = WithEd
 export type EdenCreateInfiniteQuery<
   TRoute extends RouteSchema,
   _TPath extends any[] = [],
-  TInput = InferRouteOptions<TRoute>,
+  // The exposed public type for `createInfiniteQuery` only needs the `query` from the input options.
+  TInput = InferRouteOptions<TRoute>['query'],
   TOutput = InferRouteOutput<TRoute>,
   TError = InferRouteError<TRoute>,
+  TInfiniteInput = InferRouteOptions<TRoute, ReservedInfiniteQueryKeys>,
 > = (
-  input: StoreOrVal<({} extends TInput ? void | TInput : TInput) | SkipToken>,
+  input: StoreOrVal<
+    ({} extends TInfiniteInput ? void | TInfiniteInput : TInfiniteInput) | SkipToken
+  >,
   options: EdenCreateInfiniteQueryOptions<TInput, TOutput, TError>,
 ) => EdenCreateInfiniteQueryResult<TOutput, TError, TInput>
 
 export function edenCreateInfiniteQueryOptions(
   parsedPathsAndMethod: ParsedPathAndMethod,
   context: EdenContextState<any, any>,
-  input?: any,
+  // The helper `createInfiniteQueryOptions` receives the entire options object.
+  input?: InferRouteOptions | SkipToken,
   options?: EdenCreateInfiniteQueryOptions<unknown, unknown, any>,
   config?: EdenQueryConfig,
 ): CreateInfiniteQueryOptions {
@@ -69,7 +81,9 @@ export function edenCreateInfiniteQueryOptions(
 
   const { paths, path, method } = parsedPathsAndMethod
 
-  const queryKey = getQueryKey(paths, input, 'query')
+  const isInputSkipToken = input === skipToken && typeof input !== 'object'
+
+  const queryKey = getQueryKey(paths, isInputSkipToken ? undefined : input, 'query')
 
   const defaultOptions = queryClient.getQueryDefaults(queryKey)
 
@@ -83,7 +97,7 @@ export function edenCreateInfiniteQueryOptions(
     queryKey,
   } as CreateInfiniteQueryOptions
 
-  if (input === skipToken) {
+  if (isInputSkipToken) {
     resolvedQueryOptions.queryFn = input
     return resolvedQueryOptions
   }

--- a/packages/eden-svelte-query/src/integration/hooks/create-mutation.ts
+++ b/packages/eden-svelte-query/src/integration/hooks/create-mutation.ts
@@ -150,6 +150,8 @@ export function createEdenMutation<
 export function edenCreateMutationOptions(
   parsedPathsAndMethod: ParsedPathAndMethod,
   context: EdenContextState<any, any>,
+  // Default input.
+  input?: InferRouteOptions,
   options: EdenCreateMutationOptions<any, any, any> = {},
   config?: any,
 ): CreateMutationOptions {
@@ -169,10 +171,11 @@ export function edenCreateMutationOptions(
     mutationKey,
     mutationFn: async (variables: any = {}) => {
       const { body, options } = variables as EdenCreateMutationVariables
+      const resolvedOptions = { ...input, ...options }
 
       const params = {
         ...config,
-        options,
+        options: resolvedOptions,
         body,
         path,
         method,

--- a/packages/eden-svelte-query/src/integration/hooks/create-query.ts
+++ b/packages/eden-svelte-query/src/integration/hooks/create-query.ts
@@ -59,7 +59,8 @@ export type EdenDefinedCreateQueryResult<TData, TError> = WithEdenQueryExtension
 export interface EdenCreateQuery<
   TRoute extends RouteSchema,
   _TPath extends any[] = [],
-  TInput = InferRouteOptions<TRoute>,
+  // The publicly exposed `createQuery` hook only accepts the `query` object.
+  TInput = InferRouteOptions<TRoute>['query'],
   TOutput = InferRouteOutput<TRoute>,
   TError = InferRouteError<TRoute>,
 > {
@@ -77,7 +78,8 @@ export interface EdenCreateQuery<
 export function edenCreateQueryOptions(
   parsedPathsAndMethod: ParsedPathAndMethod,
   context: EdenContextState<any, any>,
-  input?: any,
+  // The internal helper to `createQueryOptions` receives the entire input object, including `query` and `params`.
+  input?: InferRouteOptions | SkipToken,
   options?: EdenCreateQueryOptions<unknown, unknown, any>,
   config?: EdenQueryConfig,
 ): CreateQueryOptions {
@@ -85,7 +87,9 @@ export function edenCreateQueryOptions(
 
   const { paths, path, method } = parsedPathsAndMethod
 
-  const queryKey = getQueryKey(paths, input, 'query')
+  const isInputSkipToken = input === skipToken && typeof input !== 'object'
+
+  const queryKey = getQueryKey(paths, isInputSkipToken ? undefined : input, 'query')
 
   const defaultOptions = queryClient.getQueryDefaults(queryKey)
 
@@ -95,7 +99,7 @@ export function edenCreateQueryOptions(
 
   const resolvedQueryOptions = { ...queryOptions, queryKey }
 
-  if (input === skipToken) {
+  if (isInputSkipToken) {
     resolvedQueryOptions.queryFn = input
     return resolvedQueryOptions
   }

--- a/packages/eden-svelte-query/src/integration/internal/infinite-query.ts
+++ b/packages/eden-svelte-query/src/integration/internal/infinite-query.ts
@@ -15,3 +15,5 @@ export type ReservedInfiniteQueryKeys = InfiniteCursorKey | 'direction'
  */
 export type ExtractCursorType<T> =
   T extends Record<string, any> ? (T['params'] & T['query'])['cursor'] : unknown
+
+export type ExtractQueryCursor<T> = T extends Record<string, any> ? T['cursor'] : unknown

--- a/packages/eden-svelte-query/src/integration/internal/path-params.ts
+++ b/packages/eden-svelte-query/src/integration/internal/path-params.ts
@@ -1,0 +1,46 @@
+/**
+ *
+ * An eden-treaty proxy may look like these examples:
+ *
+ * eden.api.products.get({ limit: 5 })
+ * eden.api.product({ id: 'product-id' }).details.get({ limit: 5 })
+ *
+ * In the first example, the proxy is called like a function at the very end, so it is trivial
+ * to infer that the arguments are the query parameters for fetch request.
+ *
+ * In the second example, there are two function calls, and we need to heuristically determine whether
+ * it is a function call to insert a path parameter, or the actual end.
+ *
+ * Heuristic: A path parameter function call needs exactly one object with exactly one key passed as an argument.
+ */
+export function getPathParam(args: unknown[]) {
+  if (args.length !== 1) {
+    return
+  }
+
+  const argument = args[0]
+
+  if (argument == null || typeof argument !== 'object') {
+    return
+  }
+
+  const argumentKeys = Object.keys(argument)
+
+  const pathParam = argumentKeys[0]
+
+  if (argumentKeys.length !== 1 || pathParam == null) {
+    return
+  }
+
+  return { param: argument as any, key: argumentKeys[0] }
+}
+
+export type ExtractEdenTreatyRouteParams<T> = {
+  [K in keyof T as K extends `:${string}` ? K : never]: T[K]
+}
+
+export type ExtractEdenTreatyRouteParamsInput<T> = {
+  [K in keyof T as K extends `:${infer TParam}` ? TParam : never]: string | number
+}
+
+export type ExtractRouteParam<T> = T extends `:${infer TParam}` ? TParam : T

--- a/packages/eden-svelte-query/src/utils/is-store.ts
+++ b/packages/eden-svelte-query/src/utils/is-store.ts
@@ -3,6 +3,9 @@ import type { Readable } from 'svelte/store'
 
 export function isStore<T>(obj: StoreOrVal<T>): obj is Readable<T> {
   return (
-    obj != null && typeof obj === 'object' && 'subscribe' in obj && 'set' in obj && 'update' in obj
+    obj != null &&
+    typeof obj === 'object' &&
+    'subscribe' in obj &&
+    typeof obj.subscribe === 'function'
   )
 }

--- a/packages/eden-svelte-query/src/utils/literal-union.ts
+++ b/packages/eden-svelte-query/src/utils/literal-union.ts
@@ -1,0 +1,7 @@
+/**
+ * Allows you to get autocomplete even when allowing arbitrary values.
+ *
+ * For example, `'a' | 'b' | LiteralUnion<string>` allows any arbitrary string, but you
+ * get autocomplete for the value.
+ */
+export type LiteralUnion<T> = T & { _?: any }

--- a/packages/eden-svelte-query/src/utils/path-param.ts
+++ b/packages/eden-svelte-query/src/utils/path-param.ts
@@ -1,0 +1,131 @@
+import type { StoreOrVal } from '@tanstack/svelte-query'
+import { derived, get, type Readable, readable } from 'svelte/store'
+
+import type { EdenTreatyQueryRootHooks } from '../implementation/treaty'
+import { isStore } from './is-store'
+import type { LiteralUnion } from './literal-union'
+
+/**
+ *
+ * An eden-treaty proxy may look like these examples:
+ *
+ * eden.api.products.get({ limit: 5 })
+ * eden.api.product({ id: 'product-id' }).details.get({ limit: 5 })
+ *
+ * In the first example, the proxy is called like a function at the very end, so it is trivial
+ * to infer that the arguments are the query parameters for fetch request.
+ *
+ * In the second example, there are two function calls, and we need to heuristically determine whether
+ * it is a function call to insert a path parameter, or the actual end.
+ *
+ * Heuristic: A path parameter function call needs exactly one object with exactly one key passed as an argument.
+ */
+export function getPathParam(args: unknown[]) {
+  if (args.length === 0) {
+    return
+  }
+
+  const argument = args[0]
+
+  /**
+   * Extract the value of a writable.
+   */
+  const argumentValue = isStore(argument) ? get(argument) : argument
+
+  if (argumentValue == null || typeof argumentValue !== 'object') {
+    return
+  }
+
+  const argumentKeys = Object.keys(argumentValue)
+
+  const pathParam = argumentKeys[0]
+
+  if (argumentKeys.length !== 1 || pathParam == null) {
+    return
+  }
+
+  // At this point, assume that it's either a StoreOrVal with a valid object representing route params.
+
+  return { param: argument as any, key: argumentKeys[0] }
+}
+
+/**
+ * The positional index of the `input` provided to root query hooks.
+ *
+ * `undefined` if the function does not receive `input`.
+ */
+const inputPositions: Partial<
+  Record<keyof EdenTreatyQueryRootHooks | LiteralUnion<string>, number>
+> = {
+  createQuery: 0,
+  createInfiniteQuery: 0,
+}
+
+/**
+ * Directly mutate the arguments passed to the root hooks.
+ *
+ * Make sure that the interpretation of args matches up with the implementation of root hooks.
+ */
+export function mutateArgs(
+  hook: keyof EdenTreatyQueryRootHooks | LiteralUnion<string>,
+  args: unknown[],
+  params: StoreOrVal<Record<string, any>>[],
+) {
+  const inputPosition = inputPositions[hook]
+
+  if (inputPosition == null) {
+    return args
+  }
+
+  const input = args[inputPosition]
+
+  if (input == null && params.length === 0) {
+    return args
+  }
+
+  const isInputStore = isStore(input)
+
+  if (!isInputStore && !params.length) {
+    return args
+  }
+
+  const queryStore = isInputStore ? input : readable(input)
+
+  const paramsStores: Readable<Record<string, any>>[] = []
+
+  const staticParams: Record<string, any>[] = []
+
+  for (const param of params) {
+    if (isStore(param)) {
+      paramsStores.push(param)
+    } else {
+      staticParams.push(param)
+    }
+  }
+
+  console.log({ paramsStores, staticParams })
+
+  const paramsStore = derived(paramsStores, ($paramsStores) => {
+    const resolvedParams: Record<string, any> = {}
+
+    for (const param of $paramsStores) {
+      for (const key in param) {
+        resolvedParams[key] = param[key]
+      }
+    }
+
+    return resolvedParams
+  })
+
+  const inputStore = derived([queryStore, paramsStore], ([query, params]) => {
+    console.log({ params, query })
+    for (const key in staticParams) {
+      params[key] = staticParams[key]
+    }
+    return { query, params }
+  })
+
+  args[inputPosition] = inputStore
+
+  return args
+}

--- a/packages/eden-svelte-query/src/utils/path-param.ts
+++ b/packages/eden-svelte-query/src/utils/path-param.ts
@@ -103,8 +103,6 @@ export function mutateArgs(
     }
   }
 
-  console.log({ paramsStores, staticParams })
-
   const paramsStore = derived(paramsStores, ($paramsStores) => {
     const resolvedParams: Record<string, any> = {}
 
@@ -118,7 +116,6 @@ export function mutateArgs(
   })
 
   const inputStore = derived([queryStore, paramsStore], ([query, params]) => {
-    console.log({ params, query })
     for (const key in staticParams) {
       params[key] = staticParams[key]
     }

--- a/packages/eden/src/http.ts
+++ b/packages/eden/src/http.ts
@@ -59,7 +59,7 @@ export function getAbortController(
 
 export const httpQueryMethods = ['get', 'options', 'head'] as const
 
-export const httpMutationMethods = ['post', 'put', 'path', 'delete'] as const
+export const httpMutationMethods = ['post', 'put', 'patch', 'delete'] as const
 
 export const httpSubscriptionMethods = ['connect', 'subscribe'] as const
 


### PR DESCRIPTION
#  Eden Treaty Path Parameters

## Overview

Adds support for the same dynamic path parameter syntax as the [official eden treaty implementation](https://elysiajs.com/eden/treaty/overview.html#dynamic-path).

```ts
treaty.item({ name: 'Skadi' }).get.createQuery
```

## TODO
- [x] svelte-query
- [x] react-query

## Implementation

When recursively creating the proxy, append path parameters to an array that's also passed into the recursive call. A function call is heuristically determined to either be a path parameter call or a hook call. At the very end of the proxy, evaluate the accumulated path parameters into the final query options.

## Project
Closes #12 