### PR TITLE
fix(react-query, svelte-query): call root hook if hook is found

### DIFF
--- a/.changeset/bright-berries-rescue.md
+++ b/.changeset/bright-berries-rescue.md
@@ -1,0 +1,5 @@
+---
+'@ap0nia/eden-react-query': patch
+---
+
+fix(react-query): call root hooks if hook is found

--- a/.changeset/slimy-pears-explode.md
+++ b/.changeset/slimy-pears-explode.md
@@ -1,0 +1,5 @@
+---
+'@ap0nia/eden-svelte-query': patch
+---
+
+fix(eden-svelte-query): call root hooks if hook is found

--- a/examples/eden-svelte-query-basic/src/routes/+page.svelte
+++ b/examples/eden-svelte-query-basic/src/routes/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { eden } from '$lib/eden'
 
-  const hello = eden.api.index.get.createQuery({})
+  const hello = eden.api.index.get.createQuery()
 
   eden.createQueries(q => {
     return [q.api.index.get()]

--- a/packages/eden-react-query/src/implementation/treaty/index.ts
+++ b/packages/eden-react-query/src/implementation/treaty/index.ts
@@ -214,17 +214,19 @@ export function createEdenTreatyReactQueryProxy<T extends AnyElysia = AnyElysia>
       return createEdenTreatyReactQueryProxy(rootHooks, config, nextPaths, pathParams)
     },
     apply: (_target, _thisArg, args) => {
+      const pathsCopy = [...paths]
+
       const pathParam = getPathParam(args)
 
-      if (pathParam?.key != null) {
+      const hook = pathsCopy.pop() ?? ''
+
+      const isRootProperty = Object.prototype.hasOwnProperty.call(rootHooks, hook)
+
+      if (pathParam?.key != null && !isRootProperty) {
         const allPathParams = [...pathParams, pathParam.param]
         const pathsWithParams = [...paths, `:${pathParam.key}`]
         return createEdenTreatyReactQueryProxy(rootHooks, config, pathsWithParams, allPathParams)
       }
-
-      const pathsCopy = [...paths]
-
-      const hook = pathsCopy.pop() ?? ''
 
       /**
        * Hidden internal hook that returns the path array up to this point.

--- a/packages/eden-svelte-query/src/implementation/treaty/index.ts
+++ b/packages/eden-svelte-query/src/implementation/treaty/index.ts
@@ -205,7 +205,9 @@ export function createEdenTreatySvelteQueryProxy<T extends AnyElysia = AnyElysia
 
       const pathParam = getPathParam(args)
 
-      if (pathParam?.key != null) {
+      const isRootProperty = Object.prototype.hasOwnProperty.call(rootHooks, hook)
+
+      if (pathParam?.key != null && !isRootProperty) {
         const allPathParams = [...pathParams, pathParam.param]
         const pathsWithParams = [...paths, `:${pathParam.key}`]
         return createEdenTreatySvelteQueryProxy(rootHooks, config, pathsWithParams, allPathParams)


### PR DESCRIPTION
## Issue

The heuristic used to check for path params does not care whether or not the hook is a known one.

## Solution

Check whether the hook exists on `rootHooks`.

## Project

Resolves #35

Partially resolves #38 