### PR TITLE
refactor: ♻️ eden plugin

### DIFF
--- a/.changeset/fluffy-schools-join.md
+++ b/.changeset/fluffy-schools-join.md
@@ -1,0 +1,8 @@
+---
+'@ap0nia/eden': patch
+'@ap0nia/eden-next-query': patch
+'@ap0nia/eden-react-query': patch
+'@ap0nia/eden-svelte-query': patch
+---
+
+refactor(eden): make eden plugin unsafe by default

--- a/packages/eden/src/plugins/batch.ts
+++ b/packages/eden/src/plugins/batch.ts
@@ -227,7 +227,7 @@ function unBatchQueries(request: Request): URLSearchParams[] {
  * This may result in a TS error if you have "declaration": true in your tsconfig.
  * TS 4118 The type of this node cannot be serialized because its property '[EdenQueryStoreKey]' cannot be serialized.
  */
-export function batchPlugin(options?: BatchPluginOptions) {
+export function safeBatchPlugin(options?: BatchPluginOptions) {
   const plugin = <BasePath extends string>(
     elysia: Elysia<BasePath>,
   ): Elysia<
@@ -361,4 +361,8 @@ export function batchPlugin(options?: BatchPluginOptions) {
   }
 
   return plugin
+}
+
+export function batchPlugin(options?: BatchPluginOptions) {
+  return safeBatchPlugin(options)
 }

--- a/packages/eden/src/plugins/index.ts
+++ b/packages/eden/src/plugins/index.ts
@@ -26,7 +26,7 @@ export type EdenPluginOptions = EdenQueryConstraints
  *   this is at your own risk, since eden allows transformers to be specified for any request,
  *   but it's not guranteed to be parsed correctly by the server...
  */
-export function edenPlugin<T extends EdenQueryConstraints>(config: T) {
+export function safeEdenPlugin<T extends EdenQueryConstraints>(config: T) {
   const plugin = <BasePath extends string>(
     elysia: Elysia<BasePath>,
   ): Elysia<
@@ -63,6 +63,29 @@ export function edenPlugin<T extends EdenQueryConstraints>(config: T) {
   }
 
   return plugin
+}
+
+/**
+ * Combines both the batch and transform plugins, ___and orders them properly___.
+ *
+ * The transform plugin (if used) needs to be set before the batch plugin.
+ *
+ * --
+ *
+ * Type Invariants
+ *
+ * > Constraints that are captured on the type-level.
+ *
+ * If the server has enabled batching, the client can use batching if desired.
+ * If the server has NOT enabled batching, the client can NOT use a batch link.
+ *
+ * If the server has enabled a transformer, the client MUST apply the same transformer.
+ * If the server has NOT enabled any transformers, the client can opt-in to using a transformer;
+ *   this is at your own risk, since eden allows transformers to be specified for any request,
+ *   but it's not guranteed to be parsed correctly by the server...
+ */
+export function edenPlugin<T extends EdenQueryConstraints>(config: T) {
+  return safeEdenPlugin(config)
 }
 
 export * from './batch'

--- a/packages/eden/src/plugins/index.ts
+++ b/packages/eden/src/plugins/index.ts
@@ -84,7 +84,7 @@ export function safeEdenPlugin<T extends EdenQueryConstraints>(config: T) {
  *   this is at your own risk, since eden allows transformers to be specified for any request,
  *   but it's not guranteed to be parsed correctly by the server...
  */
-export function edenPlugin<T extends EdenQueryConstraints>(config: T) {
+export function edenPlugin(config: EdenQueryConstraints) {
   return safeEdenPlugin(config)
 }
 

--- a/packages/eden/src/plugins/transform.ts
+++ b/packages/eden/src/plugins/transform.ts
@@ -29,8 +29,10 @@ function isError(response: unknown): boolean {
  * @fixme:
  *
  * TS 4118 The type of this node cannot be serialized because its property '[EdenQueryStoreKey]' cannot be serialized.
+ *
+ * Turn off declaration: true and declarationMap: true
  */
-export function transformPlugin<T extends DataTransformerOptions>(transformer: T) {
+export function safeTransformPlugin<T extends DataTransformerOptions>(transformer: T) {
   const resolvedTransformer = getDataTransformer(transformer)
 
   const plugin = <BasePath extends string>(
@@ -98,4 +100,8 @@ export function transformPlugin<T extends DataTransformerOptions>(transformer: T
   }
 
   return plugin
+}
+
+export function transformPlugin(transformer: DataTransformerOptions) {
+  return safeTransformPlugin(transformer)
 }


### PR DESCRIPTION
## Issue

The `elysia` plugins are strongly typed, and can are sensitive to type changes from the upstream library.

## Solution

Make the plugins type-unsafe by default, so they're easier to use.

## Project

Somewhat resolves #49 