### PR TITLE
Update React to Peer Dependency and Adjust Version Constraints

### DIFF
--- a/packages/eden-react-query/package.json
+++ b/packages/eden-react-query/package.json
@@ -27,8 +27,7 @@
   "dependencies": {
     "@ap0nia/eden": "workspace:^",
     "@tanstack/react-query": "^5.51.16",
-    "elysia": "1.1.19",
-    "react": "^18.3.1"
+    "elysia": "1.1.19"
   },
   "devDependencies": {
     "@types/react": "^18.3.3",
@@ -36,7 +35,8 @@
   },
   "peerDependencies": {
     "@tanstack/react-query": "^5.51.16",
-    "elysia": "1.1.19"
+    "elysia": "1.1.19",
+    "react": "^18.0.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
### Summary
This PR updates the `react` dependency to be a peer dependency, ensuring that the current project's existing version of React is used. Additionally, the version constraints for React have been lowered to `^18.0.0` to accommodate a wider range of compatible versions.

### Changes
- Moved `react` from `dependencies` to `peerDependencies`.
- Lowered the version constraint for `react` to `^18.0.0`.

### Motivation
By making `react` a peer dependency, we ensure that the package does not install its own version of React, thereby avoiding potential conflicts and ensuring compatibility with the project's existing React version. Lowering the version constraint allows for greater flexibility in the versions of React that can be used with this package.
